### PR TITLE
Smooth transition

### DIFF
--- a/Resources/Public/Styles/main.css
+++ b/Resources/Public/Styles/main.css
@@ -430,7 +430,7 @@ input[type="radio"]:checked + label::before { background: #e3000b; }
 
 ol.tx-dlf-listview-list { width: 100%; list-style: none; margin: 0; padding: 0; }
 
-ol.tx-dlf-listview-list img { border: 1em solid #ffffff; max-height: 350px; }
+ol.tx-dlf-listview-list img { border: 1em solid #ffffff; max-height: 350px; transition: all 0.275s ease; }
 
 ol.tx-dlf-listview-list img:hover { max-height: 600px; }
 


### PR DESCRIPTION
I added a transition to smooth out the scaling of preview images. :)

Before:

![before](https://user-images.githubusercontent.com/180686/78291547-dec65100-7525-11ea-8d4d-bc3c2769f546.gif)

After:

![After](https://user-images.githubusercontent.com/180686/78291554-e1c14180-7525-11ea-85a2-334aa59cb206.gif)
